### PR TITLE
Fix entrypoint of rebalancer script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,4 +62,4 @@ RUN yarn abi
 RUN yarn types
 
 # Run the rebalance script
-ENTRYPOINT ["yarn" "hardhat", "run", "--no-compile", "./scripts/rebalance.ts"]
+ENTRYPOINT ["yarn", "hardhat", "run", "--no-compile", "./scripts/rebalance.ts"]


### PR DESCRIPTION
 `yarn script` definition was changed in a recent PR which breaks the rebalancer script run. 