### PR TITLE
Remove rebalancer image build from PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,6 +55,3 @@ jobs:
 
       - name: Typescript compiles correctly
         run: yarn tsc
-
-      - name: Check if docker image for rebalancer builds
-        run: docker build -t alpine-sc:temp .


### PR DESCRIPTION
The image build doesn't do anything besides a yarn install. We could consider running the rebalance script upon release to make sure rebalancing still works.