### PR TITLE
Remove abi directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ artifacts
 typechain
 hh-cache
 .openzeppelin/unknown-*.json
+abi/
 
 # Foundry
 out

--- a/abi/.gitignore
+++ b/abi/.gitignore
@@ -1,4 +1,0 @@
-# Avoid committing abi files for now
-# Keep this directory in the repo so abi extractor works
-*
-!.gitignore


### PR DESCRIPTION
- The `hardhat-abi-exporter` package will create this directory if it doesn't exist