### PR TITLE
Remove old `Withdraw` event

### DIFF
--- a/src/polygon/TwoAssetBasket.sol
+++ b/src/polygon/TwoAssetBasket.sol
@@ -155,8 +155,6 @@ contract TwoAssetBasket is ERC20, BaseRelayRecipient, DetailedShare, Pausable {
         _mint(receiver, shares);
     }
 
-    event Withdraw(address indexed sender, address indexed receiver, uint256 assets, uint256 shares);
-
     function withdraw(
         uint256 amountInput,
         address receiver,


### PR DESCRIPTION
web3.py doesn't support overloaded events: https://github.com/ethereum/web3.py/pull/1705