### PR TITLE
Use "Matic" as network for polygon contracts

### DIFF
--- a/scripts/utils/constants/blockchain.ts
+++ b/scripts/utils/constants/blockchain.ts
@@ -11,7 +11,7 @@ enum ethNetworks {
 }
 
 enum polygonNetworks {
-  MAINNET = "Mainnet",
+  MAINNET = "Matic",
   MUMBAI = "Mumbai",
 }
 


### PR DESCRIPTION
Currently, polygon contracts get added to defender as ethereum contracts.

For defender, "mainnet" means ethereum mainnet and "matic" means matic mainnet.